### PR TITLE
Discard master-slave language

### DIFF
--- a/pco-pirate.py
+++ b/pco-pirate.py
@@ -164,15 +164,15 @@ class PcoControlSection(QWidget):
 
 
         # ----------------------------------------------------------------------
-        # Master layout
+        # Main layout
 
-        masterLayout = QVBoxLayout()
-        masterLayout.addWidget(noteGroup)
+        mainLayout = QVBoxLayout()
+        mainLayout.addWidget(noteGroup)
 
         doublePanelLayout = QHBoxLayout()
         doublePanelContainer = QWidget(self)
         doublePanelContainer.setLayout(doublePanelLayout)
-        masterLayout.addWidget(doublePanelContainer)
+        mainLayout.addWidget(doublePanelContainer)
 
         leftLayout      = QVBoxLayout()
         rightLayout     = QVBoxLayout()
@@ -189,7 +189,7 @@ class PcoControlSection(QWidget):
         rightLayout.addWidget(vibratoGroup)
         rightLayout.addWidget(pwmGroup)
 
-        self.setLayout(masterLayout)
+        self.setLayout(mainLayout)
 
 # ------------------------------------------------------------------------------
 

--- a/pirate_control/pyBusPirateLite/I2Chigh.py
+++ b/pirate_control/pyBusPirateLite/I2Chigh.py
@@ -50,7 +50,7 @@ class I2Chigh(I2C):
 
 
     def command(self, i2caddr, cmd):
-        """ Writes one byte command to slave """
+        """ Writes one byte command to subordinate """
         self.send_start_bit();
         stat = self.bulk_trans(2, [i2caddr<<1, cmd]);
         self.send_stop_bit();

--- a/pirate_control/pyserial-2.6/documentation/conf.py
+++ b/pirate_control/pyserial-2.6/documentation/conf.py
@@ -33,8 +33,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'pySerial'


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.